### PR TITLE
Fix #93 add filename to output

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -57,4 +57,5 @@ you do tricky stuff like this gem from Mark Fowler
 This has been a security problem in the past, and so in ack 3 we
 no longer `eval` the contents of `--output`.  You're now restricted
 to the following variables: `$1` thru `$9`, `$_`, `$.`, `$&`, ``$` ``,
-`$'` and `$+`.  You can also embed `\t`, `\n` and `\r`.
+`$'` and `$+`.  You can also embed `\t`, `\n` and `\r` ,
+and `$f` as stand-in for `$ARGV` in normal `perl -nE` usage and `$filename` in `ack2 --output` .

--- a/ack
+++ b/ack
@@ -854,7 +854,7 @@ sub print_line_with_options {
             # on them not changing in the process of doing the s///.
             my %keep = map { ($_ => ${$_} // '') } @special_vars_used_by_opt_output;
             $keep{_} = $line if exists $keep{_}; # Manually set it because $_ gets reset in a map.
-	    $keep{f} = $filename if exists $keep{f} ; # $f = $filename
+            $keep{f} = $filename if exists $keep{f} ; # $f = $filename
             $output =~ s/\$([$special_vars_used_by_opt_output])/$keep{$1}/eg;
             App::Ack::print( join( $separator, @line_parts, $output ), $ors );
         }

--- a/ack
+++ b/ack
@@ -159,7 +159,7 @@ MAIN: {
         $opt_output =~ s/\\r/\r/g;
         $opt_output =~ s/\\t/\t/g;
 
-        my @supported_special_variables = ( 1..9, qw( _ . ` & ' + ) );
+        my @supported_special_variables = ( 1..9, qw( _ . ` & ' +  f ) );
         @special_vars_used_by_opt_output = grep { $opt_output =~ /\$$_/ } @supported_special_variables;
         $special_vars_used_by_opt_output = join( '', @special_vars_used_by_opt_output );
 
@@ -854,6 +854,7 @@ sub print_line_with_options {
             # on them not changing in the process of doing the s///.
             my %keep = map { ($_ => ${$_} // '') } @special_vars_used_by_opt_output;
             $keep{_} = $line if exists $keep{_}; # Manually set it because $_ gets reset in a map.
+	    $keep{f} = $filename if exists $keep{f} ; # $f = $filename
             $output =~ s/\$([$special_vars_used_by_opt_output])/$keep{$1}/eg;
             App::Ack::print( join( $separator, @line_parts, $output ), $ors );
         }

--- a/ack
+++ b/ack
@@ -855,7 +855,7 @@ sub print_line_with_options {
             my %keep = map { ($_ => ${$_} // '') } @special_vars_used_by_opt_output;
             $keep{_} = $line if exists $keep{_}; # Manually set it because $_ gets reset in a map.
             $keep{f} = $filename if exists $keep{f} ; # $f = $filename
-            $output =~ s/\$([$special_vars_used_by_opt_output])/$keep{$1}/eg;
+            $output =~ s/\$([$special_vars_used_by_opt_output])/$keep{$1}/ego;
             App::Ack::print( join( $separator, @line_parts, $output ), $ors );
         }
     }

--- a/lib/App/Ack/Docs/Manual.pm
+++ b/lib/App/Ack/Docs/Manual.pm
@@ -387,6 +387,15 @@ then C<$+> will contain whichever set of parentheses matched.
 
 =back
 
+=item C<$f>
+
+C<$f> is available, in C<--output> only, as stand-in for C<$ARGV> in normal C<perl -nE> usage
+and for the discovered C<$filename> usage in old C<< ack2 --output >>.
+The intended usage is to provide the grep or compile-error syntax needed for editor/IDE go-to-line integration,
+e.g. C<--output=$f:$.:$_> or C<--output=$f\t$.\t$&>
+
+=back
+
 For examples of using C<--output>, see the Cookbook section of the manual.
 
 =item B<--pager=I<program>>, B<--nopager>

--- a/t/ack-output.t
+++ b/t/ack-output.t
@@ -3,7 +3,7 @@
 use warnings;
 use strict;
 
-use Test::More tests => 38;
+use Test::More tests => 44;
 
 use lib 't';
 use Util;
@@ -277,6 +277,43 @@ HERE
     my @results = run_ack( @args, @files );
 
     lists_match( \@results, \@expected, 'Character substitutions' );
+}
+
+# $f=$filenname, needed for grep,  emulating ack2 $filename:$lineno:$_
+FILENAME_SUBSTITUTION_1 : {
+    my @expected = (
+      't/text/freedom-of-choice.txt:3:Sink, swim, go down with the ship'
+    );
+
+    my @files = qw( t/text/freedom-of-choice.txt );
+    my @args = qw( swim --output=$f:$.:$_ );
+    my @results = run_ack( @args, @files );
+
+    lists_match( \@results, \@expected, 'Filename with matching line' );
+}
+
+FILENAME_SUBSTITUTION_2 : {
+    my @expected = (
+      't/text/freedom-of-choice.txt:3:swim'
+    );
+
+    my @files = qw( t/text/freedom-of-choice.txt );
+    my @args = qw( swim --output=$f:$.:$& );
+    my @results = run_ack( @args, @files );
+
+    lists_match( \@results, \@expected, 'Filename with match' );
+}
+
+FILENAME_SUBSTITUTION_3 : {
+    my @expected = (
+      't/text/freedom-of-choice.txt:3:swim'
+    );
+
+    my @files = qw( t/text/freedom-of-choice.txt );
+    my @args = qw( (sink|swim) --output=$f:$.:$+ );
+    my @results = run_ack( @args, @files );
+
+    lists_match( \@results, \@expected, 'Filename with last match' );
 }
 
 


### PR DESCRIPTION
 Resolving issue --output to provide alternate for --filename #93

adds $f as a special variable, and fills it from $filename

Includes related unit-test, REALEASE-NOTE.md and Manual doc patches